### PR TITLE
Case single head

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -8,5 +8,7 @@
     assert_format: 3,
     assert_same: 1,
     assert_same: 2
-  ]
+  ],
+  # single_clause_on_do: false, # false/true
+  # trailing_comma: false, # false/true
 ]

--- a/lib/freedom_formatter/formatter.ex
+++ b/lib/freedom_formatter/formatter.ex
@@ -260,6 +260,7 @@ defmodule FreedomFormatter.Formatter do
       operand_nesting: 2,
       rename_deprecated_at: rename_deprecated_at,
       trailing_comma: Keyword.get(opts, :trailing_comma, false),
+      single_clause_on_do: Keyword.get(opts, :single_clause_on_do, false),
       comments: comments
     }
   end
@@ -1286,6 +1287,14 @@ defmodule FreedomFormatter.Formatter do
     [{key, line, end_line, value}]
   end
 
+  defp do_end_blocks_to_algebra(
+         [{:do, line, end_line, [{:->, _, _}] = value}],
+         %{single_clause_on_do: true} = state
+       ) do
+    {doc, state} = do_end_block_to_algebra(@empty, line, end_line, value, state)
+    {doc, state}
+  end
+
   defp do_end_blocks_to_algebra([{:do, line, end_line, value} | blocks], state) do
     {acc, state} = do_end_block_to_algebra(@empty, line, end_line, value, state)
 
@@ -1293,6 +1302,19 @@ defmodule FreedomFormatter.Formatter do
       {doc, state} = do_end_block_to_algebra(Atom.to_string(key), line, end_line, value, state)
       {line(acc, doc), state}
     end)
+  end
+
+  defp do_end_block_to_algebra(
+         key_doc,
+         line,
+         end_line,
+         [{:->, _, _}] = value,
+         %{single_clause_on_do: true} = state
+       ) do
+    case clauses_to_algebra(value, line, end_line, state) do
+      {@empty, state} -> {key_doc, state}
+      {value_doc, state} -> {key_doc |> space(value_doc), state}
+    end
   end
 
   defp do_end_block_to_algebra(key_doc, line, end_line, value, state) do
@@ -1811,6 +1833,17 @@ defmodule FreedomFormatter.Formatter do
     else
       doc
     end
+  end
+
+  defp clauses_to_algebra(
+         [{:->, _, _}] = clauses,
+         min_line,
+         max_line,
+         %{single_clause_on_do: true} = state
+       ) do
+    [clause] = add_max_line_to_last_clause(clauses, max_line)
+    {clause_doc, state} = clause_to_algebra(clause, min_line, state)
+    {clause_doc |> maybe_force_clauses([clause]), state}
   end
 
   defp clauses_to_algebra([{:->, _, _} | _] = clauses, min_line, max_line, state) do

--- a/test/code_formatter/single_clause_on_do_test.exs
+++ b/test/code_formatter/single_clause_on_do_test.exs
@@ -1,0 +1,31 @@
+Code.require_file("../test_helper.exs", __DIR__)
+
+defmodule Code.Formatter.SingleClauseOnDoTest do
+  use ExUnit.Case, async: true
+
+  import CodeFormatterHelpers
+
+  @single_clause_on_do [single_clause_on_do: true]
+
+  describe "lists" do
+    test "case with single clause" do
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert_format """
+                      def hello(world) do
+                        case world do
+                          :world -> IO.inspect world
+                        end
+                      end
+                      """,
+                      """
+                      def hello(world) do
+                        case world do :world ->
+                          IO.inspect(world)
+                        end
+                      end
+                      """,
+                      @single_clause_on_do
+      end)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new `single_clause_on_do` option, defaulting to false (vanilla behaviour).  Adds 3 functions, all clearly marked via `single_clause_on_do` in the heads to the source thus making maintenance simple, with a dedicated test file.  The source is formatted as vanilla.  All tests run successfully.

What this does is when enabled it will format `case` and such related clauses to not have a newline after the `do`.  I.E. the vanilla behaviour will do this:
```elixir
case hello do
  :world -> "!"
end
```
This will instead format this as:
```elixir
case hello do :world ->
  "!"
end
```
And yes it is enforced for a newline after the `->`.

This pattern in itself will rarely be hit by most code, however it is valuable when inline destructuring something in a pipeline to prevent the code from moving too far right, as such:
```elixir
value
|> do_something()
|> case do {:ok, value} ->
  do_things(value)
end
|> do_more()
```

This will not change what happens when there are multiple clauses.